### PR TITLE
stop marking doc/tags as 'untracked files'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.*.sw[a-z]
+doc/tags


### PR DESCRIPTION
Currently my checkout of vimlint is constantly marked 'locally modified' because Helptags creates doc/tags inside the repo. Other projects (see syntastic) have this in their gitignore file.
