### PR TITLE
メッセージ改善: searchpos() / improve message of EVL108 searchpos()

### DIFF
--- a/autoload/vimlint/builtin_arg.vim
+++ b/autoload/vimlint/builtin_arg.vim
@@ -65,11 +65,11 @@ function! s:funcs.search(vl, fname, node) " {{{
       if str =~# '[^bcenpswW]'
         call s:EVL108(a:vl, a:node, 2, a:fname, '"bcenpswW"')
       elseif str =~# 'w' && str =~# 'W'
-        call s:EVL108(a:vl, a:node, 2, a:fname, '"w" or "W"')
+        call s:EVL108(a:vl, a:node, 2, a:fname, 'either "w" or "W"')
       elseif str =~# 's' && str =~# 'n'
-        call s:EVL108(a:vl, a:node, 2, a:fname, '"s" or "n"')
+        call s:EVL108(a:vl, a:node, 2, a:fname, 'either "s" or "n"')
       elseif str =~# 'e' && str =~# 'n'
-        call s:EVL108(a:vl, a:node, 2, a:fname, '"e" or "n"')
+        call s:EVL108(a:vl, a:node, 2, a:fname, 'either "e" or "n"')
       elseif str =~# '\(.\).*\1'
         call s:EVL108(a:vl, a:node, 2, a:fname, 'once')
       endif


### PR DESCRIPTION
http://lingr.com/room/vim/archives/2014/06/27#message-19445511
`./autoload/vimshell/mappings.vim:391:30:Error: EVL108: 2nd argument of searchpos should be "e" or "n"`
あとはこういうエラーが謎です
