### PR TITLE
fix error message EVL107

### DIFF
--- a/autoload/vimlint.vim
+++ b/autoload/vimlint.vim
@@ -1084,7 +1084,7 @@ function s:VimlLint.compile_function(node, refchk) "{{{
     "  The intention, as mentioned in the quoted docs,  is only alphanumeric
     "  characters and '_', while prepending s: is allowed to make the function
     "  script-local.  Something like abc:def() was never intended to work.
-    call self.error_mes(left, 'EVL107', 'A function name does not allowed to contain a colon: `' . funcname . '`', 1)
+    call self.error_mes(left, 'EVL107', 'A function name is not allowed to contain a colon: `' . funcname . '`', 1)
   endif
 
   if self.param.func_abort && !a:node.attr.abort

--- a/doc/vimlint.txt
+++ b/doc/vimlint.txt
@@ -213,7 +213,7 @@ EVL106: local variable `v` is used without l:			*EVL106*
 	        let l:count = 1
 	    endif
 <
-EVL107: A function name does not allowd to contain a colon: `v`	*EVL107*
+EVL107: A function name is not allowed to contain a colon: `v`	*EVL107*
 >
 	    function! g:incorrect()
 	        return 0


### PR DESCRIPTION
受動態(be allowed: 許されない)なのでdoes notではなくてis notですね。また、allowdはtypoです。
