### PR TITLE
Add -u option to vimlint.sh

### DIFF
--- a/bin/vimlint.sh
+++ b/bin/vimlint.sh
@@ -9,6 +9,7 @@ usage()
 Usage ${0##*/} [-p <dir>][-l <dir>][-e errlv][-v][-E][-h][-c config] {<file>|<dir>} ...
  -p <dir>           look for vim-vimlparser in <dir>
  -l <dir>           look for vim-vimlint in <dir>
+ -u                 invoke vim with '-u NONE -i NONE'
  -h                 print this message and exit
  -e EVLxxx=n        set error level for all variables
  -e EVLxxx.var=n    set error level for the variable "var"
@@ -33,7 +34,7 @@ VOPT="-c 'set rtp+=`pwd`'"
 echo "call has_key(g:, \"vimlint#config\") | let g:vimlint#config = {}" > ${VF}
 echo "let g:vimlint#config.quiet = 1" >> ${VF}
 ERRGREP='Error|Warning'
-while getopts 'hl:p:e:vc:E' OPT; do
+while getopts 'hl:p:ue:vc:E' OPT; do
 	case "$OPT" in
 	p)
 		if [ ! -f "${OPTARG}/autoload/vimlparser.vim" ]; then
@@ -47,6 +48,8 @@ while getopts 'hl:p:e:vc:E' OPT; do
 		fi
 		VOPT="$VOPT -c 'set rtp+=$OPTARG'"
 		shift ;;
+	u)
+		VOPT="$VOPT -u NONE -i NONE" ;;
 	E)
 		ERRGREP='Error' ;;
 	e)


### PR DESCRIPTION
* -u: invoke vim with '-u NONE -i NONE'

This option makes testing in user environment easier
and also it makes `time vimlint.sh ...` a lot faster.


```
$ echo 3 | sudo tee /proc/sys/vm/drop_caches
3

$ time $HOME/.vim/bundle/vim-vimlint/bin/vimlint.sh -u \
    -l $HOME/.vim/bundle/vim-vimlint \
    -p $HOME/.vim/bundle/vim-vimlparser \
    autoload plugin

real    0m14.777s
user    0m8.550s
sys     0m0.053s

$ echo 3 | sudo tee /proc/sys/vm/drop_caches
3

$ time $HOME/.vim/bundle/vim-vimlint/bin/vimlint.sh \
    -l $HOME/.vim/bundle/vim-vimlint \
    -p $HOME/.vim/bundle/vim-vimlparser \
    autoload plugin

real    0m37.336s
user    0m9.973s
sys     0m0.193s

$ ls ~/.vim/bundle/
SudoEdit.vim              vim-flavored-markdown
ag.vim                    vim-ft-diff_fold
autodate.vim              vim-ft-markdown_fold
autodirmake.vim           vim-fugitive
capture.vim               vim-go
caw.vim                   vim-go-extra
codingstyle.vim           vim-hier
cpp-vim                   vim-javascript
current-func-info.vim     vim-operator-user
emap.vim                  vim-prettyprint
eskk.vim                  vim-qfreplace
fileutils.vim             vim-quickrun
foldCC                    vim-rails
ftl-vim-syntax            vim-ref
gist-vim                  vim-repeat
lexima.vim                vim-rooter
neocomplete.vim           vim-singleton
neomru.vim                vim-submode
neosnippet-snippets       vim-surround
neosnippet.vim            vim-tabpagecd
nextfile.vim              vim-textobj-entire
open-browser-github.vim   vim-textobj-function
open-browser.vim          vim-textobj-function-go
operator-html-escape.vim  vim-textobj-function-javascript
previm                    vim-textobj-function-perl
qfhist.vim                vim-textobj-indent
quickey.vim               vim-textobj-jabraces
ref-plugins               vim-textobj-user
restart.vim               vim-themis
skkdict.vim               vim-trailing-whitespace
surround-config           vim-vimlint
transbuffer.vim           vim-vimlparser
typescript-vim            vim-visualstar
unite.vim                 vimdoc-ja
vim-altercmd              vimproc
vim-anzu                  vital.vim
vim-brightest             vivacious.vim
vim-fakeclip              webapi-vim
```