### PR TITLE
vimlint.sh: fix temporary file removal

### DIFF
--- a/bin/vimlint.sh
+++ b/bin/vimlint.sh
@@ -30,7 +30,7 @@ if [ "$#" = 0 ]; then
 fi
 
 VF=$( mktemp -t "${0##*/}"-$$.XXXXXXXX ) || exit 1
-trap 'rm -f "$TF"' EXIT HUP INT QUIT TERM
+trap 'rm -f "$VF"' EXIT HUP INT QUIT TERM
 
 VERBOSE=0
 VOPT="-c 'set rtp+=`pwd`'"
@@ -89,7 +89,7 @@ while getopts 'hl:p:ue:vc:E' OPT; do
 done
 
 TF=$( mktemp -t "${0##*/}"-$$.XXXXXXXX ) || exit 1
-trap 'rm -f "$TF"' EXIT HUP INT QUIT TERM
+trap 'rm -f "$VF" "$TF"' EXIT HUP INT QUIT TERM
 
 RET=0
 VOPT="${VOPT} -c 'source ${VF}'"


### PR DESCRIPTION
The script was not removing the first temporary file because of a typo.
Also, traps are not cumulative, so we have to remove both files when
we reset the trap command.