### PR TITLE
vimlint.sh: fix trap

### DIFF
--- a/bin/vimlint.sh
+++ b/bin/vimlint.sh
@@ -30,7 +30,16 @@ if [ "$#" = 0 ]; then
 fi
 
 VF=$( mktemp -t "${0##*/}"-$$.XXXXXXXX ) || exit 1
-trap 'rm -f "$TF"' EXIT HUP INT QUIT TERM
+cleanup() {
+  ret=$?
+  for f in "$VF" "$TF"; do
+    if [ -f "$f" ]; then
+      rm "$f"
+    fi
+  done
+  exit $ret
+}
+trap cleanup EXIT HUP INT QUIT TERM
 
 VERBOSE=0
 VOPT="-c 'set rtp+=`pwd`'"
@@ -89,7 +98,6 @@ while getopts 'hl:p:ue:vc:E' OPT; do
 done
 
 TF=$( mktemp -t "${0##*/}"-$$.XXXXXXXX ) || exit 1
-trap 'rm -f "$TF"' EXIT HUP INT QUIT TERM
 
 RET=0
 VOPT="${VOPT} -c 'source ${VF}'"


### PR DESCRIPTION
- $VF was never removed
- use a function with more defensive code, and exit with SIGINT etc

Closes https://github.com/syngan/vim-vimlint/pull/113.