### PR TITLE
Use `grep -E` over `egrep`

### DIFF
--- a/bin/vimlint.sh
+++ b/bin/vimlint.sh
@@ -103,10 +103,10 @@ while [ $# -gt 0 ]; do
 		VIM="$VIMLINT_VIM $VOPT -es -N -c 'call vimlint#vimlint(\"$1\", {\"output\": \"${TF}\"})' -c 'qall!'"
 		eval "${VIM}" || exit
 		if [ ${VERBOSE} = 0 ]; then
-			egrep -a -w "${ERRGREP}" "$TF" && RET=2
+			grep -E -a -w "${ERRGREP}" "$TF" && RET=2
 		else
 			cat "${TF}"
-			egrep -a -w "${ERRGREP}" "$TF" > /dev/null 2>&1
+			grep -E -a -w "${ERRGREP}" "$TF" > /dev/null 2>&1
 			if [ $? = 0 ]; then
 				RET=2
 			fi


### PR DESCRIPTION
`egrep` has been deprecated in GNU grep since version 2.5.3 (2007) and since version 3.8 emits a warning[1]

> egrep: warning: egrep is obsolescent; using grep -E

Avoid this warning by following its suggestion.

[1] https://lists.gnu.org/archive/html/info-gnu/2022-09/msg00001.html